### PR TITLE
update: use readSnapshots instead of doc

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ function ShareDBAccess(backend, options){
   this.allow = {}
   this.deny = {}
 
-  backend.use('doc', this.docHandler.bind(this))
+  backend.use('readSnapshots', this.docHandler.bind(this))
   backend.use('apply', this.applyHandler.bind(this))
   backend.use('commit', this.commitHandler.bind(this))
 


### PR DESCRIPTION
sharedb has released 1.0.0-beta.13, 'doc' middleware action has been deprecated, use 'readSnapshots' instead