### PR TITLE
update: use readSnapshots instead of doc

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ function ShareDBAccess(backend, options){
   this.allow = {}
   this.deny = {}
 
-  backend.use('doc', this.docHandler.bind(this))
+  backend.use('readSnapshots', this.docHandler.bind(this))
   backend.use('apply', this.applyHandler.bind(this))
   backend.use('commit', this.commitHandler.bind(this))
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ function ShareDBAccess(backend, options){
   this.allow = {}
   this.deny = {}
 
-  backend.use('readSnapshots', this.docHandler.bind(this))
+  backend.use('readSnapshots', this.readSnapshotsHandler.bind(this))
   backend.use('apply', this.applyHandler.bind(this))
   backend.use('commit', this.commitHandler.bind(this))
 
@@ -167,12 +167,20 @@ ShareDBAccess.prototype.applyHandlerAsync = async function(shareRequest) {
   return
 }
 
-ShareDBAccess.prototype.docHandler = function (shareRequest, done){
-  this.docHandlerAsync(shareRequest)
-    .then((res) => done(res))
-    .catch((err) => done(err))
+ShareDBAccess.prototype.readSnapshotsHandler = function (shareRequest, done){
+  Promise.all(shareRequest.snapshots.map(snapshot => {
+    return this.docHandlerAsync({
+      collection: shareRequest.collection,
+      id: snapshot.id,
+      snapshot: snapshot,
+      agent: shareRequest.agent
+    })
+  }))
+  .then(reasons => {
+    done(reasons.find(reason => reason))
+  })
+  .catch(err => done(err))
 }
-
 
 ShareDBAccess.prototype.docHandlerAsync = async function (shareRequest){
   // ++++++++++++++++++++++++++++++++ READ ++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
sharedb has released 1.0.0-beta.13, 'doc' middleware action has been deprecated, use 'readSnapshots' instead